### PR TITLE
Fix for an array bounds error in removeListeners

### DIFF
--- a/lib/MongoMQ.js
+++ b/lib/MongoMQ.js
@@ -407,7 +407,7 @@ MongoMQ.prototype.removeListeners = function(event, handler){
   }
   if(!(event||handler)) return false;
   var found = false, listener;
-  for(var i = l; i>-1; i--){
+  for(var i = l-1; i>-1; i--){
     found = false;
     listener = self.listeners[i];
     if(event) found = (event==listener.event)||(listener.event=='*');


### PR DESCRIPTION
The loop was starting on listeners.length, but should have started on listeners.length-1
